### PR TITLE
Transition to JupyterLab 2.0.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,30 @@
+name: Build
+
+on:
+  push:
+    branches: master
+  pull_request:
+    branches: '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Install node
+      uses: actions/setup-node@v1
+      with:
+       node-version: '12.x'
+    - name: Install Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.7'
+        architecture: 'x64'
+    - name: Install dependencies
+      run: python -m pip install jupyterlab
+    - name: Build the extension
+      run: |
+        jlpm && jlpm run build
+        jupyter labextension install .
+        python -m jupyterlab.browser_check

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .vscode/*
-lib/*
-node_modules/*
+*.bundle.*
+lib/
+node_modules/
+*.egg-info/
+.ipynb_checkpoints
+*.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Jupyterlab-Tensorboard
 
+![Github Actions Status](https://github.com/chaoleili/jupyterlab_tensorboard/workflows/Build/badge.svg)
+
 A JupyterLab extension for tensorboard.
 
 > Note: This project is just a frontend extension for tensorboard on jupyterlab. It uses the [jupyter_tensorboard](https://github.com/lspvic/jupyter_tensorboard) project as tensorboard backend.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1248,9 +1248,9 @@
       "integrity": "sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q=="
     },
     "typescript": {
-      "version": "3.7.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
-      "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true
     },
     "typestyle": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,471 +1,522 @@
 {
   "name": "jupyterlab_tensorboard",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@babel/runtime": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.0.tgz",
-      "integrity": "sha512-2xsuyZ0R0RBFwjgae5NpXk8FcfH4qovj5cEM5VEeB7KXnKqzaisIu2HSV/mCEISolJJuR4wkViUGYujA8MH9tw==",
+      "version": "7.8.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.7.tgz",
+      "integrity": "sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==",
       "requires": {
-        "regenerator-runtime": "0.13.2"
+        "regenerator-runtime": "^0.13.4"
       }
     },
     "@blueprintjs/core": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/@blueprintjs/core/-/core-3.17.1.tgz",
-      "integrity": "sha512-VROTlhBaNaRN9kfscTQwZqRvGZmZYGfPkzcP8w50+wF/XMiK0xNEF4mRNQKXLNIduIZta5uPagZgIh68UG5dTg==",
+      "version": "3.24.0",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/core/-/core-3.24.0.tgz",
+      "integrity": "sha512-qW29DDPjzYsT27J6n97C0jZ1ifvEEziwNC98UhaKdSE7I8qxbLsb+ft2JOop+pEX4ab67T1lhQKAiQjWCPKZng==",
       "requires": {
-        "@blueprintjs/icons": "3.9.1",
-        "@types/dom4": "2.0.1",
-        "classnames": "2.2.6",
-        "dom4": "2.1.5",
-        "normalize.css": "8.0.1",
-        "popper.js": "1.15.0",
-        "react-popper": "1.3.3",
-        "react-transition-group": "2.9.0",
-        "resize-observer-polyfill": "1.5.1",
-        "tslib": "1.10.0"
+        "@blueprintjs/icons": "^3.14.0",
+        "@types/dom4": "^2.0.1",
+        "classnames": "^2.2",
+        "dom4": "^2.1.5",
+        "normalize.css": "^8.0.1",
+        "popper.js": "^1.15.0",
+        "react-lifecycles-compat": "^3.0.4",
+        "react-popper": "^1.3.7",
+        "react-transition-group": "^2.9.0",
+        "resize-observer-polyfill": "^1.5.1",
+        "tslib": "~1.10.0"
       }
     },
     "@blueprintjs/icons": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@blueprintjs/icons/-/icons-3.9.1.tgz",
-      "integrity": "sha512-2EU9Xot0lkztDp8xVnBi5/71jgG1Rmsfz0LycBX/T16H0qGO7i+XEbZbpJjSvmr/UzhTpxQ/Yh5XGBc2U2zG4w==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/icons/-/icons-3.14.0.tgz",
+      "integrity": "sha512-cvQ3CSdy0DqVqcXcPqSxoycJw497TVP5goyE6xCFlVs84477ahxh7Uung6J+CCoDVBuI87h576LtuyjwSxorvQ==",
       "requires": {
-        "classnames": "2.2.6",
-        "tslib": "1.10.0"
+        "classnames": "^2.2",
+        "tslib": "~1.10.0"
       }
     },
     "@blueprintjs/select": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@blueprintjs/select/-/select-3.9.0.tgz",
-      "integrity": "sha512-TmInLtGFc3My78KTmf9JUw5gawxdO7oxn3bEQDQbWPuvb/1K0u0et+dTVlwGTk9GiNopQ2NtoCj+GQ75miF9QA==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/select/-/select-3.12.0.tgz",
+      "integrity": "sha512-rABlv5M+h7onuoUuNsratyiukPnkdblDm7lt7GT4fbRmJglSsKylNnfHogNDZkMMHqmgmVB05mgzBQ+kcLA1cw==",
       "requires": {
-        "@blueprintjs/core": "3.17.1",
-        "classnames": "2.2.6",
-        "tslib": "1.10.0"
+        "@blueprintjs/core": "^3.24.0",
+        "classnames": "^2.2",
+        "tslib": "~1.10.0"
       }
     },
+    "@fortawesome/fontawesome-free": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.12.1.tgz",
+      "integrity": "sha512-ZtjIIFplxncqxvogq148C3hBLQE+W3iJ8E4UvJ09zIJUgzwLcROsWwFDErVSXY2Plzao5J9KUYNHKHMEUYDMKw=="
+    },
     "@jupyterlab/application": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/application/-/application-1.0.0.tgz",
-      "integrity": "sha512-fETjESqQKcJHDnyEyczz8KNIN8q8eLHjwiyWnx4aw44TkwbomANcdhuzkn7X1nw13zvroPEIc8Jfx0/2DXp5Gg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/application/-/application-2.0.2.tgz",
+      "integrity": "sha512-/4KG2jBaUx5s+uuEKpTjJC3kOEQWKmpDNorOLP8PPsdWMl1VlrYJJmnpvIUOLLnJZAycnK7O4z7jBDp6wv4S2Q==",
       "requires": {
-        "@jupyterlab/apputils": "1.0.0",
-        "@jupyterlab/coreutils": "3.0.0",
-        "@jupyterlab/docregistry": "1.0.0",
-        "@jupyterlab/rendermime": "1.0.0",
-        "@jupyterlab/rendermime-interfaces": "1.3.0",
-        "@jupyterlab/services": "4.0.0",
-        "@phosphor/algorithm": "1.1.3",
-        "@phosphor/application": "1.6.4",
-        "@phosphor/commands": "1.6.3",
-        "@phosphor/coreutils": "1.3.1",
-        "@phosphor/disposable": "1.2.0",
-        "@phosphor/messaging": "1.2.3",
-        "@phosphor/properties": "1.1.3",
-        "@phosphor/signaling": "1.2.3",
-        "@phosphor/widgets": "1.8.1",
-        "font-awesome": "4.7.0"
+        "@fortawesome/fontawesome-free": "^5.12.0",
+        "@jupyterlab/apputils": "^2.0.2",
+        "@jupyterlab/coreutils": "^4.0.2",
+        "@jupyterlab/docregistry": "^2.0.2",
+        "@jupyterlab/rendermime": "^2.0.2",
+        "@jupyterlab/rendermime-interfaces": "^2.0.1",
+        "@jupyterlab/services": "^5.0.2",
+        "@jupyterlab/statedb": "^2.0.1",
+        "@jupyterlab/ui-components": "^2.0.2",
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/application": "^1.8.4",
+        "@lumino/commands": "^1.10.1",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/messaging": "^1.3.3",
+        "@lumino/polling": "^1.0.4",
+        "@lumino/properties": "^1.1.6",
+        "@lumino/signaling": "^1.3.5",
+        "@lumino/widgets": "^1.11.1"
       }
     },
     "@jupyterlab/apputils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/apputils/-/apputils-1.0.0.tgz",
-      "integrity": "sha512-YreD3ltKyLsFReZGwVOL7w2lOO5ujl8gNMNO8oh8gSeDtQMMzIPJCtS5bRIOe1qH+aWyk6OuS+SNyXPUpstb6A==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/apputils/-/apputils-2.0.2.tgz",
+      "integrity": "sha512-mJO/h3x+jtKXPJegdOB5LkvOWLjACKElWCWZXGtizHASYXKrCCAYQ3VDkmrdx2zibu+gDqlMFtbPJxMvYt65Vw==",
       "requires": {
-        "@jupyterlab/coreutils": "3.0.0",
-        "@jupyterlab/services": "4.0.0",
-        "@jupyterlab/ui-components": "1.0.0",
-        "@phosphor/algorithm": "1.1.3",
-        "@phosphor/commands": "1.6.3",
-        "@phosphor/coreutils": "1.3.1",
-        "@phosphor/disposable": "1.2.0",
-        "@phosphor/domutils": "1.1.3",
-        "@phosphor/messaging": "1.2.3",
-        "@phosphor/properties": "1.1.3",
-        "@phosphor/signaling": "1.2.3",
-        "@phosphor/virtualdom": "1.1.3",
-        "@phosphor/widgets": "1.8.1",
-        "@types/react": "16.8.23",
-        "react": "16.8.6",
-        "react-dom": "16.8.6",
-        "sanitize-html": "1.20.1"
-      },
-      "dependencies": {
-        "@phosphor/domutils": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/@phosphor/domutils/-/domutils-1.1.3.tgz",
-          "integrity": "sha512-5CtLAhURQXXHhNXfQydDk/luG1cDVnhlu/qw7gz8/9pht0KXIAmNg/M0LKxx2oJ9+YMNCLVWxAnHAU0yrDpWSA=="
-        }
+        "@jupyterlab/coreutils": "^4.0.2",
+        "@jupyterlab/services": "^5.0.2",
+        "@jupyterlab/settingregistry": "^2.0.1",
+        "@jupyterlab/statedb": "^2.0.1",
+        "@jupyterlab/ui-components": "^2.0.2",
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/commands": "^1.10.1",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/domutils": "^1.1.7",
+        "@lumino/messaging": "^1.3.3",
+        "@lumino/properties": "^1.1.6",
+        "@lumino/signaling": "^1.3.5",
+        "@lumino/virtualdom": "^1.6.1",
+        "@lumino/widgets": "^1.11.1",
+        "@types/react": "~16.9.16",
+        "react": "~16.9.0",
+        "react-dom": "~16.9.0",
+        "sanitize-html": "~1.20.1"
       }
     },
     "@jupyterlab/codeeditor": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/codeeditor/-/codeeditor-1.0.0.tgz",
-      "integrity": "sha512-unv4RmDCXsWCW+ieL8je3X6sJValYQNVoHNWA1/RD6mOydh4G9sDmCZ6WM1DboG1OHnMr6pzz0HmA/jvA/JO1w==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/codeeditor/-/codeeditor-2.0.2.tgz",
+      "integrity": "sha512-l1SrLJN3QNXQB1WH0YrMjKsM3ZOPAYI05r7hBS0U1Kq5vpb73LQ+8w08s15y/yPcuCgibVhonIEQCyiu1wUA3w==",
       "requires": {
-        "@jupyterlab/coreutils": "3.0.0",
-        "@jupyterlab/observables": "2.2.0",
-        "@phosphor/coreutils": "1.3.1",
-        "@phosphor/disposable": "1.2.0",
-        "@phosphor/dragdrop": "1.3.3",
-        "@phosphor/messaging": "1.2.3",
-        "@phosphor/signaling": "1.2.3",
-        "@phosphor/widgets": "1.8.1"
+        "@jupyterlab/coreutils": "^4.0.2",
+        "@jupyterlab/nbformat": "^2.0.1",
+        "@jupyterlab/observables": "^3.0.1",
+        "@jupyterlab/ui-components": "^2.0.2",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/dragdrop": "^1.5.1",
+        "@lumino/messaging": "^1.3.3",
+        "@lumino/signaling": "^1.3.5",
+        "@lumino/widgets": "^1.11.1"
       }
     },
     "@jupyterlab/codemirror": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/codemirror/-/codemirror-1.0.0.tgz",
-      "integrity": "sha512-HIgBxNygC02h6hVpNOZujcCgUge/bS0rDHTzqbpq+ZEqe13SNZ8JBJrz0opuZ0YDfoPVKpZcOs45BD3sv92dIQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/codemirror/-/codemirror-2.0.2.tgz",
+      "integrity": "sha512-IQm/yiPHJtQgJlQt/qqX0/pChGsQn/2JIe38q6R2Hi6V4DbI8WpyVOBhhKIoUqWwGNLsZgoCna2dnB+R7j0Emw==",
       "requires": {
-        "@jupyterlab/apputils": "1.0.0",
-        "@jupyterlab/codeeditor": "1.0.0",
-        "@jupyterlab/coreutils": "3.0.0",
-        "@jupyterlab/observables": "2.2.0",
-        "@jupyterlab/statusbar": "1.0.0",
-        "@phosphor/algorithm": "1.1.3",
-        "@phosphor/commands": "1.6.3",
-        "@phosphor/coreutils": "1.3.1",
-        "@phosphor/disposable": "1.2.0",
-        "@phosphor/signaling": "1.2.3",
-        "@phosphor/widgets": "1.8.1",
-        "codemirror": "5.47.0",
-        "react": "16.8.6"
+        "@jupyterlab/apputils": "^2.0.2",
+        "@jupyterlab/codeeditor": "^2.0.2",
+        "@jupyterlab/coreutils": "^4.0.2",
+        "@jupyterlab/nbformat": "^2.0.1",
+        "@jupyterlab/observables": "^3.0.1",
+        "@jupyterlab/statusbar": "^2.0.2",
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/commands": "^1.10.1",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/polling": "^1.0.4",
+        "@lumino/signaling": "^1.3.5",
+        "@lumino/widgets": "^1.11.1",
+        "codemirror": "~5.49.2",
+        "react": "~16.9.0"
       }
     },
     "@jupyterlab/coreutils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-3.0.0.tgz",
-      "integrity": "sha512-l48G1qhff4CZpsxjje92S6caLUixzfDMAD5vjNZL9obexUAMF+344cpVWsm2r2CQROUW7bPB8wjAtFbp8nK/QQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-4.0.2.tgz",
+      "integrity": "sha512-v4RXIAeykoPjIymdCxUxPLl8lkn18jroGnDflZjvdMk21TZQQJSIrJ5bjrGByh9scco8yNg46z8m1LPguF3z8A==",
       "requires": {
-        "@phosphor/commands": "1.6.3",
-        "@phosphor/coreutils": "1.3.1",
-        "@phosphor/disposable": "1.2.0",
-        "@phosphor/properties": "1.1.3",
-        "@phosphor/signaling": "1.2.3",
-        "ajv": "6.10.0",
-        "json5": "2.1.0",
-        "minimist": "1.2.0",
-        "moment": "2.24.0",
-        "path-posix": "1.0.0",
-        "url-parse": "1.4.7"
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/signaling": "^1.3.5",
+        "minimist": "~1.2.0",
+        "moment": "^2.24.0",
+        "path-posix": "~1.0.0",
+        "url-parse": "~1.4.7"
+      }
+    },
+    "@jupyterlab/docmanager": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/docmanager/-/docmanager-2.0.2.tgz",
+      "integrity": "sha512-59/Oa/akU2pzKF96OFOV+vz8s9xpEVowe6NIhJooOxU6AZdDsN3o2sMCVkoCsnlnwPQ8N6siGKbBP9QlPk0taQ==",
+      "requires": {
+        "@jupyterlab/apputils": "^2.0.2",
+        "@jupyterlab/coreutils": "^4.0.2",
+        "@jupyterlab/docregistry": "^2.0.2",
+        "@jupyterlab/services": "^5.0.2",
+        "@jupyterlab/statusbar": "^2.0.2",
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/messaging": "^1.3.3",
+        "@lumino/properties": "^1.1.6",
+        "@lumino/signaling": "^1.3.5",
+        "@lumino/widgets": "^1.11.1",
+        "react": "~16.9.0"
       }
     },
     "@jupyterlab/docregistry": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/docregistry/-/docregistry-1.0.0.tgz",
-      "integrity": "sha512-Gm+KCf/I+P0eQfl5yDbrYSdRW9ZdicDwcmJuSNGaeZVOuBuEP+w+s89shICaSqo2c1vFhmikUPSo3LZQP3gWgw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/docregistry/-/docregistry-2.0.2.tgz",
+      "integrity": "sha512-kGk1AIzcXkpaNI1pwFbyLYiQuSdJUQ/j2A+G8WYhcY64Zwp1tayr0VvaRuEzwcDHueiBYesaarCxY7VNP+Cf3g==",
       "requires": {
-        "@jupyterlab/apputils": "1.0.0",
-        "@jupyterlab/codeeditor": "1.0.0",
-        "@jupyterlab/codemirror": "1.0.0",
-        "@jupyterlab/coreutils": "3.0.0",
-        "@jupyterlab/observables": "2.2.0",
-        "@jupyterlab/rendermime": "1.0.0",
-        "@jupyterlab/rendermime-interfaces": "1.3.0",
-        "@jupyterlab/services": "4.0.0",
-        "@phosphor/algorithm": "1.1.3",
-        "@phosphor/coreutils": "1.3.1",
-        "@phosphor/disposable": "1.2.0",
-        "@phosphor/messaging": "1.2.3",
-        "@phosphor/signaling": "1.2.3",
-        "@phosphor/widgets": "1.8.1"
+        "@jupyterlab/apputils": "^2.0.2",
+        "@jupyterlab/codeeditor": "^2.0.2",
+        "@jupyterlab/codemirror": "^2.0.2",
+        "@jupyterlab/coreutils": "^4.0.2",
+        "@jupyterlab/observables": "^3.0.1",
+        "@jupyterlab/rendermime": "^2.0.2",
+        "@jupyterlab/rendermime-interfaces": "^2.0.1",
+        "@jupyterlab/services": "^5.0.2",
+        "@jupyterlab/ui-components": "^2.0.2",
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/messaging": "^1.3.3",
+        "@lumino/signaling": "^1.3.5",
+        "@lumino/widgets": "^1.11.1"
+      }
+    },
+    "@jupyterlab/filebrowser": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/filebrowser/-/filebrowser-2.0.2.tgz",
+      "integrity": "sha512-jztQ3NVfkjd4LqtQYxsfVmGf5D5pCk4F9/ktH2PESA3V02uQMkuRZ24u0cikdzz05cEp05Oe94/9gba9SPCE0A==",
+      "requires": {
+        "@jupyterlab/apputils": "^2.0.2",
+        "@jupyterlab/coreutils": "^4.0.2",
+        "@jupyterlab/docmanager": "^2.0.2",
+        "@jupyterlab/docregistry": "^2.0.2",
+        "@jupyterlab/services": "^5.0.2",
+        "@jupyterlab/statedb": "^2.0.1",
+        "@jupyterlab/statusbar": "^2.0.2",
+        "@jupyterlab/ui-components": "^2.0.2",
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/domutils": "^1.1.7",
+        "@lumino/dragdrop": "^1.5.1",
+        "@lumino/messaging": "^1.3.3",
+        "@lumino/polling": "^1.0.4",
+        "@lumino/signaling": "^1.3.5",
+        "@lumino/widgets": "^1.11.1",
+        "react": "~16.9.0"
       }
     },
     "@jupyterlab/launcher": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/launcher/-/launcher-1.0.0.tgz",
-      "integrity": "sha512-Ilat7tIuydyhve5ZUOCNz12aO+lafGMkxIo+5xj66r9/tu5mMhyAu9mmH8dgDji9bGAzdg3vCsEUk+57axUKFA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/launcher/-/launcher-2.0.2.tgz",
+      "integrity": "sha512-3vFRUCvHJkpBSp3/6e2sDwAdOLW8h957wnw6pAvysiwvgBNB66QZ4P72/HhN5QuhDDz6VQn//M5HztKz0NRF4A==",
       "requires": {
-        "@jupyterlab/apputils": "1.0.0",
-        "@phosphor/algorithm": "1.1.3",
-        "@phosphor/commands": "1.6.3",
-        "@phosphor/coreutils": "1.3.1",
-        "@phosphor/disposable": "1.2.0",
-        "@phosphor/properties": "1.1.3",
-        "@phosphor/widgets": "1.8.1",
-        "react": "16.8.6"
+        "@jupyterlab/apputils": "^2.0.2",
+        "@jupyterlab/ui-components": "^2.0.2",
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/commands": "^1.10.1",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/properties": "^1.1.6",
+        "@lumino/widgets": "^1.11.1",
+        "react": "~16.9.0"
       }
     },
     "@jupyterlab/mainmenu": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/mainmenu/-/mainmenu-1.0.1.tgz",
-      "integrity": "sha512-xIKn4RjWEb5SwRM4cTvDWuLso3buf3v9dvDlry1UGMa3qT0e3aPmIdmzeSV4BrxMMVWUihJSlZXwnJfSvS6XgQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/mainmenu/-/mainmenu-2.0.2.tgz",
+      "integrity": "sha512-jeDx1uYE4QpAVWy3XdJIQ73+J1Mb5YXRrQkTG4S0SsT248Kkl7uz0i2j+EE7RNJlGvJlD1t+SjSuOtegZvRpnA==",
       "requires": {
-        "@jupyterlab/apputils": "1.0.1",
-        "@jupyterlab/services": "4.0.1",
-        "@phosphor/algorithm": "1.1.3",
-        "@phosphor/commands": "1.6.3",
-        "@phosphor/coreutils": "1.3.1",
-        "@phosphor/disposable": "1.2.0",
-        "@phosphor/widgets": "1.8.1"
-      },
-      "dependencies": {
-        "@jupyterlab/apputils": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/apputils/-/apputils-1.0.1.tgz",
-          "integrity": "sha512-crY5PjndVrspFdo/k8JchaC+OU7aOYIXmYhcYGLD7uwt/G6CpZgHSEA/4YuoxulmL0mG9bu0GD19ARSROxISkQ==",
-          "requires": {
-            "@jupyterlab/coreutils": "3.0.0",
-            "@jupyterlab/services": "4.0.1",
-            "@jupyterlab/ui-components": "1.0.0",
-            "@phosphor/algorithm": "1.1.3",
-            "@phosphor/commands": "1.6.3",
-            "@phosphor/coreutils": "1.3.1",
-            "@phosphor/disposable": "1.2.0",
-            "@phosphor/domutils": "1.1.3",
-            "@phosphor/messaging": "1.2.3",
-            "@phosphor/properties": "1.1.3",
-            "@phosphor/signaling": "1.2.3",
-            "@phosphor/virtualdom": "1.1.3",
-            "@phosphor/widgets": "1.8.1",
-            "@types/react": "16.8.23",
-            "react": "16.8.6",
-            "react-dom": "16.8.6",
-            "sanitize-html": "1.20.1"
-          }
-        },
-        "@jupyterlab/services": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-4.0.1.tgz",
-          "integrity": "sha512-gsErfZra65U3xh2jQu652/8mAb/LwAAYHVVybthTgZfh+ffWES04P80RDfq3nYBGIp8swXo/LFMKJEUGjaczyg==",
-          "requires": {
-            "@jupyterlab/coreutils": "3.0.0",
-            "@jupyterlab/observables": "2.2.0",
-            "@phosphor/algorithm": "1.1.3",
-            "@phosphor/coreutils": "1.3.1",
-            "@phosphor/disposable": "1.2.0",
-            "@phosphor/signaling": "1.2.3",
-            "node-fetch": "2.6.0",
-            "ws": "7.0.1"
-          }
-        },
-        "@phosphor/domutils": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/@phosphor/domutils/-/domutils-1.1.3.tgz",
-          "integrity": "sha512-5CtLAhURQXXHhNXfQydDk/luG1cDVnhlu/qw7gz8/9pht0KXIAmNg/M0LKxx2oJ9+YMNCLVWxAnHAU0yrDpWSA=="
-        }
+        "@jupyterlab/apputils": "^2.0.2",
+        "@jupyterlab/services": "^5.0.2",
+        "@jupyterlab/ui-components": "^2.0.2",
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/commands": "^1.10.1",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/widgets": "^1.11.1"
+      }
+    },
+    "@jupyterlab/nbformat": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/nbformat/-/nbformat-2.0.1.tgz",
+      "integrity": "sha512-rlf4A3PKxqDV98IeXf/VtdhqcbnKvBRGL+VNxhMOZe3e+DmjIBilRE+VpHmXovwEanOAkNl0fD5Xk3HAkqxxGQ==",
+      "requires": {
+        "@lumino/coreutils": "^1.4.2"
       }
     },
     "@jupyterlab/observables": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-2.2.0.tgz",
-      "integrity": "sha512-/oi7vl70yAX5QTXmZafyDSwU8fT1Oa/MdpDDYGkc5IklW0kU3NDqSoawfLovkdgGZvCOCM+6JQqUPRdhn8VZqg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-3.0.1.tgz",
+      "integrity": "sha512-iD7w8JYBRT9UXVS3IvljvoDf0ZiHQEu1Pm+784UTa27Az0i6idyV1iWZ+xIHtV+s7ampVjMGiBbqXD6m4HRNpg==",
       "requires": {
-        "@phosphor/algorithm": "1.1.3",
-        "@phosphor/coreutils": "1.3.1",
-        "@phosphor/disposable": "1.2.0",
-        "@phosphor/messaging": "1.2.3",
-        "@phosphor/signaling": "1.2.3"
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/messaging": "^1.3.3",
+        "@lumino/signaling": "^1.3.5"
       }
     },
     "@jupyterlab/rendermime": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime/-/rendermime-1.0.0.tgz",
-      "integrity": "sha512-Alje439y7kHYsF6RmRnYGm6yYvUHoMeHk5Z6TcYMDsDq3DlE3Yx3Ra93ykMpY0ZtjtgGhFus78bPVOkUxg24hw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime/-/rendermime-2.0.2.tgz",
+      "integrity": "sha512-JUGUteRLrwEHX5kPU1rLAIzChEwEQyxDbSCes63fgO5Hn+JXNKKQexWXeHZOm5l1JBGNiokQCz8Jy6fQHmEMYQ==",
       "requires": {
-        "@jupyterlab/apputils": "1.0.0",
-        "@jupyterlab/codemirror": "1.0.0",
-        "@jupyterlab/coreutils": "3.0.0",
-        "@jupyterlab/observables": "2.2.0",
-        "@jupyterlab/rendermime-interfaces": "1.3.0",
-        "@jupyterlab/services": "4.0.0",
-        "@phosphor/algorithm": "1.1.3",
-        "@phosphor/coreutils": "1.3.1",
-        "@phosphor/messaging": "1.2.3",
-        "@phosphor/signaling": "1.2.3",
-        "@phosphor/widgets": "1.8.1",
-        "lodash.escape": "4.0.1",
-        "marked": "0.6.2"
+        "@jupyterlab/apputils": "^2.0.2",
+        "@jupyterlab/codemirror": "^2.0.2",
+        "@jupyterlab/coreutils": "^4.0.2",
+        "@jupyterlab/nbformat": "^2.0.1",
+        "@jupyterlab/observables": "^3.0.1",
+        "@jupyterlab/rendermime-interfaces": "^2.0.1",
+        "@jupyterlab/services": "^5.0.2",
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/messaging": "^1.3.3",
+        "@lumino/signaling": "^1.3.5",
+        "@lumino/widgets": "^1.11.1",
+        "lodash.escape": "^4.0.1",
+        "marked": "^0.8.0"
       }
     },
     "@jupyterlab/rendermime-interfaces": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime-interfaces/-/rendermime-interfaces-1.3.0.tgz",
-      "integrity": "sha512-04ohT/xdTcdp/TKuNMqY1MLwh7IWyjbMrQXiuwanE8xo52fIe6OIK0DENwc6VDMej1+8NVSU7rX42urLCex0sA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime-interfaces/-/rendermime-interfaces-2.0.1.tgz",
+      "integrity": "sha512-QYJcQNKNmrBXHXC31AvBRYk+QqKB0rZrvVXbhggFXBQiYQX1K/lnFvKjphmhhnpUhLKtgUrex+04cJ9Kek00HA==",
       "requires": {
-        "@phosphor/coreutils": "1.3.1",
-        "@phosphor/widgets": "1.8.1"
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/widgets": "^1.11.1"
       }
     },
     "@jupyterlab/services": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-4.0.0.tgz",
-      "integrity": "sha512-yCchogfzZqGWXagDJDRxsEMbKwsmf+EFVJRzf5H5OKZs7c/0yNemhG2qjRSmcErD87nUezB3NHkJSVPqz11D3g==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-5.0.2.tgz",
+      "integrity": "sha512-gBwXikSRWIrj0XiuYMSXd0TXLZJrE18rTtRwrvne0T/gJPg0+4JbORPkaKfFdbX84oQv8XLOT74xUHSPDhst0A==",
       "requires": {
-        "@jupyterlab/coreutils": "3.0.0",
-        "@jupyterlab/observables": "2.2.0",
-        "@phosphor/algorithm": "1.1.3",
-        "@phosphor/coreutils": "1.3.1",
-        "@phosphor/disposable": "1.2.0",
-        "@phosphor/signaling": "1.2.3",
-        "node-fetch": "2.6.0",
-        "ws": "7.0.1"
+        "@jupyterlab/coreutils": "^4.0.2",
+        "@jupyterlab/nbformat": "^2.0.1",
+        "@jupyterlab/observables": "^3.0.1",
+        "@jupyterlab/settingregistry": "^2.0.1",
+        "@jupyterlab/statedb": "^2.0.1",
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/polling": "^1.0.4",
+        "@lumino/signaling": "^1.3.5",
+        "node-fetch": "^2.6.0",
+        "ws": "^7.2.0"
+      }
+    },
+    "@jupyterlab/settingregistry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/settingregistry/-/settingregistry-2.0.1.tgz",
+      "integrity": "sha512-38c5CFXLLNT1zKk0vS/UoD7TA90YpOrs/I5Zc8wY8GIl31IzTmTgre5H5cFSgvgg/imEbsYVWiUXtvTuQHGDWw==",
+      "requires": {
+        "@jupyterlab/statedb": "^2.0.1",
+        "@lumino/commands": "^1.10.1",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/signaling": "^1.3.5",
+        "ajv": "^6.10.2",
+        "json5": "^2.1.1"
+      }
+    },
+    "@jupyterlab/statedb": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/statedb/-/statedb-2.0.1.tgz",
+      "integrity": "sha512-M8Z9yc5grOa0dspEFBkB3qetAozPKbXYryOCaB2/MYBalTaZfNivJyVVnxf3xQRKolYavOn9ohONmuQq0OMFWQ==",
+      "requires": {
+        "@lumino/commands": "^1.10.1",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/properties": "^1.1.6",
+        "@lumino/signaling": "^1.3.5"
       }
     },
     "@jupyterlab/statusbar": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/statusbar/-/statusbar-1.0.0.tgz",
-      "integrity": "sha512-UjLsRdVCwHJjUApU+n9C6mQCbKfL+2wmCAeQXd1p5R3SXmsn2VGh6EWCW733uMY2+K2Fqwwjf8ryJ1LwUc9+iQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/statusbar/-/statusbar-2.0.2.tgz",
+      "integrity": "sha512-CGSaIm62ABWrQzAt6Jr79Px1iJMZw+LqlSVGMUDK7uPpeQ0w2Sk0V2B9bydSqJyDyzb/Ja495CYRqLu6rJn94A==",
       "requires": {
-        "@jupyterlab/apputils": "1.0.0",
-        "@jupyterlab/codeeditor": "1.0.0",
-        "@jupyterlab/coreutils": "3.0.0",
-        "@jupyterlab/services": "4.0.0",
-        "@phosphor/algorithm": "1.1.3",
-        "@phosphor/coreutils": "1.3.1",
-        "@phosphor/disposable": "1.2.0",
-        "@phosphor/messaging": "1.2.3",
-        "@phosphor/signaling": "1.2.3",
-        "@phosphor/widgets": "1.8.1",
-        "react": "16.8.6",
-        "typestyle": "2.0.3"
+        "@jupyterlab/apputils": "^2.0.2",
+        "@jupyterlab/codeeditor": "^2.0.2",
+        "@jupyterlab/coreutils": "^4.0.2",
+        "@jupyterlab/services": "^5.0.2",
+        "@jupyterlab/ui-components": "^2.0.2",
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/messaging": "^1.3.3",
+        "@lumino/polling": "^1.0.4",
+        "@lumino/signaling": "^1.3.5",
+        "@lumino/widgets": "^1.11.1",
+        "csstype": "~2.6.9",
+        "react": "~16.9.0",
+        "typestyle": "^2.0.4"
       }
     },
     "@jupyterlab/ui-components": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/ui-components/-/ui-components-1.0.0.tgz",
-      "integrity": "sha512-rR9I/wsznbuOj09gYvEWQo0fnze3ehK2dPWLY6ToE4k8qj9s39ViY48/jOoaQSaLLRaMD8M8B8ZWY0Cf+400bA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/ui-components/-/ui-components-2.0.2.tgz",
+      "integrity": "sha512-yQ/M3ZtA/Zo8qsvvcwe17qdeTE7xZ6U5l5M/6OVvxIMKR0qXnqSpv8w7jJAgbRusr29Dj8tHbdrEMFethlfwUg==",
       "requires": {
-        "@blueprintjs/core": "3.17.1",
-        "@blueprintjs/icons": "3.9.1",
-        "@blueprintjs/select": "3.9.0",
-        "react": "16.8.6"
+        "@blueprintjs/core": "^3.22.2",
+        "@blueprintjs/select": "^3.11.2",
+        "@jupyterlab/coreutils": "^4.0.2",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/signaling": "^1.3.5",
+        "@lumino/virtualdom": "^1.6.1",
+        "@lumino/widgets": "^1.11.1",
+        "react": "~16.9.0",
+        "react-dom": "~16.9.0",
+        "typestyle": "^2.0.4"
       }
     },
-    "@phosphor/algorithm": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@phosphor/algorithm/-/algorithm-1.1.3.tgz",
-      "integrity": "sha512-+dkdYTBglR+qGnLVQdCvYojNZMGxf+xSl1Jeksha3pm7niQktSFz2aR5gEPu/nI5LM8T8slTpqE4Pjvq8P+IVA=="
+    "@lumino/algorithm": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lumino/algorithm/-/algorithm-1.2.3.tgz",
+      "integrity": "sha512-XBJ/homcm7o8Y9G6MzYvf0FF7SVqUCzvkIO01G2mZhCOnkZZhZ9c4uNOcE2VjSHNxHv2WU0l7d8rdhyKhmet+A=="
     },
-    "@phosphor/application": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/@phosphor/application/-/application-1.6.4.tgz",
-      "integrity": "sha512-cGSC6JWxW3BmTzHRIjS8x/p3nC9IXWdeS0HiO/iZvmT6NbTEMBreEGM6No+2KWqr2VkyQ7l03cCB3h9mMeyvMw==",
+    "@lumino/application": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/@lumino/application/-/application-1.8.4.tgz",
+      "integrity": "sha512-f+CgggJ/9jopHT6db76+BjsiPBHjv6fgReU/vKtRGg8rsDjNRDefoWd9bWGWRuPiGymBY8c/+9Kyq5v0UDs5vg==",
       "requires": {
-        "@phosphor/commands": "1.6.3",
-        "@phosphor/coreutils": "1.3.1",
-        "@phosphor/widgets": "1.8.1"
+        "@lumino/commands": "^1.10.1",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/widgets": "^1.11.1"
       }
     },
-    "@phosphor/collections": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@phosphor/collections/-/collections-1.1.3.tgz",
-      "integrity": "sha512-J2U1xd2e5LtqoOJt4kynrjDNeHhVpJjuY2/zA0InS5kyOuWmvy79pt/KJ22n0LBNcU/fjkImqtQmbrC2Z4q2xQ==",
+    "@lumino/collections": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lumino/collections/-/collections-1.2.3.tgz",
+      "integrity": "sha512-lrSTb7kru/w8xww8qWqHHhHO3GkoQeXST2oNkOEbWNEO4wuBIHoKPSOmXpUwu58UykBUfd5hL5wbkeTzyNMONg==",
       "requires": {
-        "@phosphor/algorithm": "1.1.3"
+        "@lumino/algorithm": "^1.2.3"
       }
     },
-    "@phosphor/commands": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@phosphor/commands/-/commands-1.6.3.tgz",
-      "integrity": "sha512-PYNHWv6tbXAfAtKiqXuT0OBJvwbJ+RRTV60MBykMF7Vqz9UaZ9n2e/eB2EAGEFccF0PnjTCvBEZgarwwMVi8Hg==",
+    "@lumino/commands": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@lumino/commands/-/commands-1.10.1.tgz",
+      "integrity": "sha512-HGtXtqKD1WZJszJ42u2DyM3sgxrLal66IoHSJjbn2ygcEVCKDK73NSzoaQtXFtiissMedzKl8aIRXB3uyeEOlw==",
       "requires": {
-        "@phosphor/algorithm": "1.1.3",
-        "@phosphor/coreutils": "1.3.1",
-        "@phosphor/disposable": "1.2.0",
-        "@phosphor/domutils": "1.1.3",
-        "@phosphor/keyboard": "1.1.3",
-        "@phosphor/signaling": "1.2.3"
-      },
-      "dependencies": {
-        "@phosphor/domutils": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/@phosphor/domutils/-/domutils-1.1.3.tgz",
-          "integrity": "sha512-5CtLAhURQXXHhNXfQydDk/luG1cDVnhlu/qw7gz8/9pht0KXIAmNg/M0LKxx2oJ9+YMNCLVWxAnHAU0yrDpWSA=="
-        }
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/domutils": "^1.1.7",
+        "@lumino/keyboard": "^1.1.6",
+        "@lumino/signaling": "^1.3.5",
+        "@lumino/virtualdom": "^1.6.1"
       }
     },
-    "@phosphor/coreutils": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@phosphor/coreutils/-/coreutils-1.3.1.tgz",
-      "integrity": "sha512-9OHCn8LYRcPU/sbHm5v7viCA16Uev3gbdkwqoQqlV+EiauDHl70jmeL7XVDXdigl66Dz0LI11C99XOxp+s3zOA=="
+    "@lumino/coreutils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@lumino/coreutils/-/coreutils-1.4.2.tgz",
+      "integrity": "sha512-SmQ4YDANe25rZd0bLoW7LVAHmgySjkrJmyNPnPW0GrpBt2u4/6D+EQJ8PCCMNWuJvrljBCdlmgOFsT38qYhfcw=="
     },
-    "@phosphor/disposable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@phosphor/disposable/-/disposable-1.2.0.tgz",
-      "integrity": "sha512-4PoWoffdrLyWOW5Qv7I8//owvZmv57YhaxetAMWeJl13ThXc901RprL0Gxhtue2ZxL2PtUjM1207HndKo2FVjA==",
+    "@lumino/disposable": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@lumino/disposable/-/disposable-1.3.5.tgz",
+      "integrity": "sha512-IWDAd+nysBnwLhEtW7M62PVk84OEex9OEktZsS6V+19n/o8/Rw4ccL0pt0GFby01CsVK0YcELDoDaMUZsMiAmA==",
       "requires": {
-        "@phosphor/algorithm": "1.1.3",
-        "@phosphor/signaling": "1.2.3"
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/signaling": "^1.3.5"
       }
     },
-    "@phosphor/domutils": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@phosphor/domutils/-/domutils-1.1.2.tgz",
-      "integrity": "sha1-4u/rBS85jEK5O4npurJq8VzABRQ="
+    "@lumino/domutils": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@lumino/domutils/-/domutils-1.1.7.tgz",
+      "integrity": "sha512-NPysY8XfpCvLNvDe+z1caIUPxOLXWRPQMUAjOj/EhggRyXadan6Lm/5uO6M9S5gW/v9QUXT4+1Sxe3WXz0nRCA=="
     },
-    "@phosphor/dragdrop": {
+    "@lumino/dragdrop": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lumino/dragdrop/-/dragdrop-1.5.1.tgz",
+      "integrity": "sha512-MFg/hy6hHdPwBZypBue5mlrBzjoNrtBQzzJW+kbM5ftAOvS99ZRgyMMlMQcbsHd+6yib9NOQ64Hd8P8uZEWTdw==",
+      "requires": {
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5"
+      }
+    },
+    "@lumino/keyboard": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@lumino/keyboard/-/keyboard-1.1.6.tgz",
+      "integrity": "sha512-W6pqe0TXRfGOoz1ZK1PRmuGZUWpmdoJArrzwmduUf0t2r06yl56S7w76gxrB7ExTidNPPaOWydGIosPgdgZf5A=="
+    },
+    "@lumino/messaging": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@phosphor/dragdrop/-/dragdrop-1.3.3.tgz",
-      "integrity": "sha512-+SrlGsVQwY8OHCWxE/Zvihpk6Rc6bytJDqOUUTZqdL8hvM9QZeopAFioPDxuo1pTj87Um6cR4ekvbTU4KZ/90w==",
+      "resolved": "https://registry.npmjs.org/@lumino/messaging/-/messaging-1.3.3.tgz",
+      "integrity": "sha512-J+0m1aywl64I9/dr9fzE9IwC+eq90T5gUi1hCXP1MFnZh4aLUymmRV5zFw1CNh/vYlNnEu72xxEuhfCfuhiy8g==",
       "requires": {
-        "@phosphor/coreutils": "1.3.1",
-        "@phosphor/disposable": "1.2.0"
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/collections": "^1.2.3"
       }
     },
-    "@phosphor/keyboard": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@phosphor/keyboard/-/keyboard-1.1.3.tgz",
-      "integrity": "sha512-dzxC/PyHiD6mXaESRy6PZTd9JeK+diwG1pyngkyUf127IXOEzubTIbu52VSdpGBklszu33ws05BAGDa4oBE4mQ=="
-    },
-    "@phosphor/messaging": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@phosphor/messaging/-/messaging-1.2.3.tgz",
-      "integrity": "sha512-89Ps4uSRNOEQoepB/0SDoyPpNUWd6VZnmbMetmeXZJHsuJ1GLxtnq3WBdl7UCVNsw3W9NC610pWaDCy/BafRlg==",
+    "@lumino/polling": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@lumino/polling/-/polling-1.0.4.tgz",
+      "integrity": "sha512-9OYIDTohToj6SLrxOr+FbeyPvirBU/r53FgmPxulcDgUVnVk4tqTSLIJAUu3mjJd9hnmZZqpSn9ppyjQAo3qSg==",
       "requires": {
-        "@phosphor/algorithm": "1.1.3",
-        "@phosphor/collections": "1.1.3"
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/signaling": "^1.3.5"
       }
     },
-    "@phosphor/properties": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@phosphor/properties/-/properties-1.1.3.tgz",
-      "integrity": "sha512-GiglqzU77s6+tFVt6zPq9uuyu/PLQPFcqZt914ZhJ4cN/7yNI/SLyMzpYZ56IRMXvzK9TUgbRna6URE3XAwFUg=="
+    "@lumino/properties": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@lumino/properties/-/properties-1.1.6.tgz",
+      "integrity": "sha512-QnZa1IB7sr4Tawf0OKvwgZAptxDRK7DUAMJ71zijXNXH4FlxyThzOWXef51HHFsISKYa8Rn3rysOwtc62XkmXw=="
     },
-    "@phosphor/signaling": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@phosphor/signaling/-/signaling-1.2.3.tgz",
-      "integrity": "sha512-DMwS0m9OgfY5ljpTsklRQPUQpTyg4obz85FyImRDacUVxUVbas95djIDEbU4s1TMzdHBBO+gfki3V4giXUvXzw==",
+    "@lumino/signaling": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@lumino/signaling/-/signaling-1.3.5.tgz",
+      "integrity": "sha512-6jniKrLrJOXKJmaJyU7hr6PBzE4GJ5Wms5hc/yzNKKDBxGSEPdtNJlW3wTNUuSTTtF/9ItN8A8ZC/G0yIu53Tw==",
       "requires": {
-        "@phosphor/algorithm": "1.1.3"
+        "@lumino/algorithm": "^1.2.3"
       }
     },
-    "@phosphor/virtualdom": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@phosphor/virtualdom/-/virtualdom-1.1.3.tgz",
-      "integrity": "sha512-V8PHhhnZCRa5esrC4q5VthqlLtxTo9ZV1mZ6b4YEloapca1S1nggZSQhrSlltXQjtYNUaWJZUZ/BlFD8wFtIEQ==",
+    "@lumino/virtualdom": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@lumino/virtualdom/-/virtualdom-1.6.1.tgz",
+      "integrity": "sha512-+KdzSw8TCPwvK6qhZr4xTyp6HymvEb2Da0xPdi4RsVUNhYf2gBI03uidXHx76Vx5OIbEgCn1B+0srxvm2ZbWsQ==",
       "requires": {
-        "@phosphor/algorithm": "1.1.3"
+        "@lumino/algorithm": "^1.2.3"
       }
     },
-    "@phosphor/widgets": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@phosphor/widgets/-/widgets-1.8.1.tgz",
-      "integrity": "sha512-OY5T0nAioYTitPks/lCHm7a6QpjRB/XviIT2j6WtYm5J1U8MluIPpClqZ/NQbZfm23BYpmJeiQQyZA+5YphsDA==",
+    "@lumino/widgets": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@lumino/widgets/-/widgets-1.11.1.tgz",
+      "integrity": "sha512-f4QDe6lVNPcjL8Vb20BiP0gzbT1rx0/1Hc719u5oW9c0Z/xrXMWwNhnb/zYM/kBBVBe3omLmCfJOiNuE0oZl0A==",
       "requires": {
-        "@phosphor/algorithm": "1.1.3",
-        "@phosphor/commands": "1.6.3",
-        "@phosphor/coreutils": "1.3.1",
-        "@phosphor/disposable": "1.2.0",
-        "@phosphor/domutils": "1.1.3",
-        "@phosphor/dragdrop": "1.3.3",
-        "@phosphor/keyboard": "1.1.3",
-        "@phosphor/messaging": "1.2.3",
-        "@phosphor/properties": "1.1.3",
-        "@phosphor/signaling": "1.2.3",
-        "@phosphor/virtualdom": "1.1.3"
-      },
-      "dependencies": {
-        "@phosphor/domutils": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/@phosphor/domutils/-/domutils-1.1.3.tgz",
-          "integrity": "sha512-5CtLAhURQXXHhNXfQydDk/luG1cDVnhlu/qw7gz8/9pht0KXIAmNg/M0LKxx2oJ9+YMNCLVWxAnHAU0yrDpWSA=="
-        }
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/commands": "^1.10.1",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/domutils": "^1.1.7",
+        "@lumino/dragdrop": "^1.5.1",
+        "@lumino/keyboard": "^1.1.6",
+        "@lumino/messaging": "^1.3.3",
+        "@lumino/properties": "^1.1.6",
+        "@lumino/signaling": "^1.3.5",
+        "@lumino/virtualdom": "^1.6.1"
       }
     },
     "@types/dom4": {
@@ -474,28 +525,28 @@
       "integrity": "sha512-kSkVAvWmMZiCYtvqjqQEwOmvKwcH+V4uiv3qPQ8pAh1Xl39xggGEo8gHUqV4waYGHezdFw0rKBR8Jt0CrQSDZA=="
     },
     "@types/prop-types": {
-      "version": "15.7.1",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.1.tgz",
-      "integrity": "sha512-CFzn9idOEpHrgdw8JsoTkaDDyRWk1jrzIV8djzcgpq0y9tG4B4lFT+Nxh52DVpDXV+n4+NPNv7M1Dj5uMp6XFg=="
+      "version": "15.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
     },
     "@types/react": {
-      "version": "16.8.23",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.23.tgz",
-      "integrity": "sha512-abkEOIeljniUN9qB5onp++g0EY38h7atnDHxwKUFz1r3VH1+yG1OKi2sNPTyObL40goBmfKFpdii2lEzwLX1cA==",
+      "version": "16.9.23",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.23.tgz",
+      "integrity": "sha512-SsGVT4E7L2wLN3tPYLiF20hmZTPGuzaayVunfgXzUn1x4uHVsKH6QDJQ/TdpHqwsTLd4CwrmQ2vOgxN7gE24gw==",
       "requires": {
-        "@types/prop-types": "15.7.1",
-        "csstype": "2.6.5"
+        "@types/prop-types": "*",
+        "csstype": "^2.2.0"
       }
     },
     "ajv": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
-      "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
+      "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
       "requires": {
-        "fast-deep-equal": "2.0.1",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.4.1",
-        "uri-js": "4.2.2"
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       }
     },
     "ansi-styles": {
@@ -503,23 +554,13 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "requires": {
-        "color-convert": "1.9.3"
+        "color-convert": "^1.9.0"
       }
     },
     "array-uniq": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
       "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
-    },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
-    },
-    "async-limiter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -533,7 +574,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -542,9 +583,9 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "requires": {
-        "ansi-styles": "3.2.1",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "5.5.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       }
     },
     "classnames": {
@@ -553,9 +594,9 @@
       "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
     },
     "codemirror": {
-      "version": "5.47.0",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.47.0.tgz",
-      "integrity": "sha512-kV49Fr+NGFHFc/Imsx6g180hSlkGhuHxTSDDmDHOuyln0MQYFLixDY4+bFkBVeCEiepYfDimAF/e++9jPJk4QA=="
+      "version": "5.49.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.49.2.tgz",
+      "integrity": "sha512-dwJ2HRPHm8w51WB5YTF9J7m6Z5dtkqbU9ntMZ1dqXyFB9IpjoUFDj80ahRVEoVanfIp6pfASJbOlbWdEf8FOzQ=="
     },
     "color-convert": {
       "version": "1.9.3",
@@ -576,40 +617,68 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "core-js": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
-    },
     "create-react-context": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.2.2.tgz",
-      "integrity": "sha512-KkpaLARMhsTsgp0d2NA/R94F/eDLbhXERdIq3LvX2biCAXcDvHYoOqHfWCHf1+OLj+HKBotLG3KqaOOf+C1C+A==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.3.0.tgz",
+      "integrity": "sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==",
       "requires": {
-        "fbjs": "0.8.17",
-        "gud": "1.0.0"
+        "gud": "^1.0.0",
+        "warning": "^4.0.3"
       }
     },
     "csstype": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.5.tgz",
-      "integrity": "sha512-JsTaiksRsel5n7XwqPAfB0l3TFKdpjW/kgAELf9vrb5adGA7UCPLajKK5s3nFrcFm3Rkyp/Qkgl73ENc1UY3cA=="
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.9.tgz",
+      "integrity": "sha512-xz39Sb4+OaTsULgUERcCk+TJj8ylkL4aSVDQiX/ksxbELSqwkgt4d4RD7fovIdgJGSuNYqwZEiVjYY5l0ask+Q=="
+    },
+    "deep-equal": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+      "requires": {
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0"
+      }
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
     },
     "dom-helpers": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
       "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
       "requires": {
-        "@babel/runtime": "7.5.0"
+        "@babel/runtime": "^7.1.2"
       }
     },
     "dom-serializer": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
-      "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
+      "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
       "requires": {
-        "domelementtype": "1.3.1",
-        "entities": "1.1.2"
+        "domelementtype": "^2.0.1",
+        "entities": "^2.0.0"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
+          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ=="
+        },
+        "entities": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
+          "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw=="
+        }
       }
     },
     "dom4": {
@@ -627,7 +696,7 @@
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
       "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
       "requires": {
-        "domelementtype": "1.3.1"
+        "domelementtype": "1"
       }
     },
     "domutils": {
@@ -635,16 +704,8 @@
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
       "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
       "requires": {
-        "dom-serializer": "0.1.1",
-        "domelementtype": "1.3.1"
-      }
-    },
-    "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "requires": {
-        "iconv-lite": "0.4.24"
+        "dom-serializer": "0",
+        "domelementtype": "1"
       }
     },
     "entities": {
@@ -652,39 +713,48 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
       "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
     },
+    "es-abstract": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
+      "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
+      "requires": {
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.1.5",
+        "is-regex": "^1.0.5",
+        "object-inspect": "^1.7.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.0",
+        "string.prototype.trimleft": "^2.1.1",
+        "string.prototype.trimright": "^2.1.1"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
     },
     "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
-    },
-    "fbjs": {
-      "version": "0.8.17",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
-      "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
-      "requires": {
-        "core-js": "1.2.7",
-        "isomorphic-fetch": "2.2.1",
-        "loose-envify": "1.4.0",
-        "object-assign": "4.1.1",
-        "promise": "7.3.1",
-        "setimmediate": "1.0.5",
-        "ua-parser-js": "0.7.20"
-      }
-    },
-    "font-awesome": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
-      "integrity": "sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "free-style": {
       "version": "2.6.1",
@@ -697,18 +767,23 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
     "glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "gud": {
@@ -716,30 +791,35 @@
       "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
       "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
     },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    },
+    "has-symbols": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
     },
     "htmlparser2": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
       "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
       "requires": {
-        "domelementtype": "1.3.1",
-        "domhandler": "2.4.2",
-        "domutils": "1.7.0",
-        "entities": "1.1.2",
-        "inherits": "2.0.3",
-        "readable-stream": "3.4.0"
-      }
-    },
-    "iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "requires": {
-        "safer-buffer": "2.1.2"
+        "domelementtype": "^1.3.1",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^3.1.1"
       }
     },
     "inflight": {
@@ -748,38 +828,44 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
-    "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    "is-arguments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
     },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+    "is-callable": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+      "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
+    },
+    "is-date-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
+    },
+    "is-regex": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+      "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
       "requires": {
-        "node-fetch": "1.7.3",
-        "whatwg-fetch": "3.0.0"
-      },
-      "dependencies": {
-        "node-fetch": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-          "requires": {
-            "encoding": "0.1.12",
-            "is-stream": "1.1.0"
-          }
-        }
+        "has": "^1.0.3"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "requires": {
+        "has-symbols": "^1.0.1"
       }
     },
     "js-tokens": {
@@ -793,11 +879,11 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json5": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
-      "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
+      "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
       "requires": {
-        "minimist": "1.2.0"
+        "minimist": "^1.2.0"
       }
     },
     "lodash.clonedeep": {
@@ -826,22 +912,22 @@
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
     "lodash.mergewith": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
-      "integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ=="
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
     },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "requires": {
-        "js-tokens": "4.0.0"
+        "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
     "marked": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.6.2.tgz",
-      "integrity": "sha512-LqxwVH3P/rqKX4EKGz7+c2G9r98WeM/SW34ybhgNGhUQNKtf1GmmSkJ6cDGJ/t6tiyae49qRkpyTw2B9HOrgUA=="
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.0.tgz",
+      "integrity": "sha512-MyUe+T/Pw4TZufHkzAfDj6HarCBWia2y27/bhuYkTaiUnfDYFnCP3KUN+9oM7Wi6JA2rymtVYbQu3spE0GCmxQ=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -849,13 +935,13 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.4.tgz",
+      "integrity": "sha512-wTiNDqe4D2rbTJGZk1qcdZgFtY0/r+iuE6GDT7V0/+Gu5MLpIDm4+CssDECR79OJs/OxLPXMzdxy153b5Qy3hg=="
     },
     "moment": {
       "version": "2.24.0",
@@ -882,13 +968,39 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
+    "object-inspect": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
+    },
+    "object-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.2.tgz",
+      "integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ=="
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "path-is-absolute": {
@@ -903,18 +1015,18 @@
       "integrity": "sha1-BrJhE/Vr6rBCVFojv6iAA8ysJg8="
     },
     "popper.js": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.15.0.tgz",
-      "integrity": "sha512-w010cY1oCUmI+9KwwlWki+r5jxKfTFDVoadl7MSrIujHU5MJ5OR6HTDj6Xo8aoR/QsA56x8jKjA59qGH4ELtrA=="
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
     },
     "postcss": {
-      "version": "7.0.17",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.17.tgz",
-      "integrity": "sha512-546ZowA+KZ3OasvQZHsbuEpysvwTZNGJv9EfyCQdsIDltPSWHAeTQ5fQy/Npi2ZDtLI3zs7Ps/p6wThErhm9fQ==",
+      "version": "7.0.27",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+      "integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
       "requires": {
-        "chalk": "2.4.2",
-        "source-map": "0.6.1",
-        "supports-color": "6.1.0"
+        "chalk": "^2.4.2",
+        "source-map": "^0.6.1",
+        "supports-color": "^6.1.0"
       },
       "dependencies": {
         "supports-color": {
@@ -922,17 +1034,9 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
-      }
-    },
-    "promise": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "requires": {
-        "asap": "2.0.6"
       }
     },
     "prop-types": {
@@ -940,9 +1044,9 @@
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
       "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
       "requires": {
-        "loose-envify": "1.4.0",
-        "object-assign": "4.1.1",
-        "react-is": "16.8.6"
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
       }
     },
     "punycode": {
@@ -956,31 +1060,30 @@
       "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
     },
     "react": {
-      "version": "16.8.6",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.8.6.tgz",
-      "integrity": "sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==",
+      "version": "16.9.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.9.0.tgz",
+      "integrity": "sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==",
       "requires": {
-        "loose-envify": "1.4.0",
-        "object-assign": "4.1.1",
-        "prop-types": "15.7.2",
-        "scheduler": "0.13.6"
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2"
       }
     },
     "react-dom": {
-      "version": "16.8.6",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.6.tgz",
-      "integrity": "sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==",
+      "version": "16.9.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.9.0.tgz",
+      "integrity": "sha512-YFT2rxO9hM70ewk9jq0y6sQk8cL02xm4+IzYBz75CQGlClQQ1Bxq0nhHF6OtSbit+AIahujJgb/CPRibFkMNJQ==",
       "requires": {
-        "loose-envify": "1.4.0",
-        "object-assign": "4.1.1",
-        "prop-types": "15.7.2",
-        "scheduler": "0.13.6"
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.15.0"
       }
     },
     "react-is": {
-      "version": "16.8.6",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
-      "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
+      "version": "16.13.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.0.tgz",
+      "integrity": "sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA=="
     },
     "react-lifecycles-compat": {
       "version": "3.0.4",
@@ -988,16 +1091,17 @@
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "react-popper": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.3.tgz",
-      "integrity": "sha512-ynMZBPkXONPc5K4P5yFWgZx5JGAUIP3pGGLNs58cfAPgK67olx7fmLp+AdpZ0+GoQ+ieFDa/z4cdV6u7sioH6w==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.7.tgz",
+      "integrity": "sha512-nmqYTx7QVjCm3WUZLeuOomna138R1luC4EqkW3hxJUrAe+3eNz3oFCLYdnPwILfn0mX1Ew2c3wctrjlUMYYUww==",
       "requires": {
-        "@babel/runtime": "7.5.0",
-        "create-react-context": "0.2.2",
-        "popper.js": "1.15.0",
-        "prop-types": "15.7.2",
-        "typed-styles": "0.0.7",
-        "warning": "4.0.3"
+        "@babel/runtime": "^7.1.2",
+        "create-react-context": "^0.3.0",
+        "deep-equal": "^1.1.1",
+        "popper.js": "^1.14.4",
+        "prop-types": "^15.6.1",
+        "typed-styles": "^0.0.7",
+        "warning": "^4.0.2"
       }
     },
     "react-transition-group": {
@@ -1005,26 +1109,35 @@
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
       "integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
       "requires": {
-        "dom-helpers": "3.4.0",
-        "loose-envify": "1.4.0",
-        "prop-types": "15.7.2",
-        "react-lifecycles-compat": "3.0.4"
+        "dom-helpers": "^3.4.0",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2",
+        "react-lifecycles-compat": "^3.0.4"
       }
     },
     "readable-stream": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-      "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
       "requires": {
-        "inherits": "2.0.3",
-        "string_decoder": "1.2.0",
-        "util-deprecate": "1.0.2"
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
-      "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.4.tgz",
+      "integrity": "sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g=="
+    },
+    "regexp.prototype.flags": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
+      "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
+      }
     },
     "requires-port": {
       "version": "1.0.0",
@@ -1037,54 +1150,44 @@
       "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "dev": true,
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.1.3"
       }
     },
     "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
-    "safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
     },
     "sanitize-html": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.20.1.tgz",
       "integrity": "sha512-txnH8TQjaQvg2Q0HY06G6CDJLVYCpbnxrdO0WN8gjCKaU5J0KbyGYhZxx5QJg3WLZ1lB7XU9kDkfrCXUozqptA==",
       "requires": {
-        "chalk": "2.4.2",
-        "htmlparser2": "3.10.1",
-        "lodash.clonedeep": "4.5.0",
-        "lodash.escaperegexp": "4.1.2",
-        "lodash.isplainobject": "4.0.6",
-        "lodash.isstring": "4.0.1",
-        "lodash.mergewith": "4.6.1",
-        "postcss": "7.0.17",
-        "srcset": "1.0.0",
-        "xtend": "4.0.1"
+        "chalk": "^2.4.1",
+        "htmlparser2": "^3.10.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.mergewith": "^4.6.1",
+        "postcss": "^7.0.5",
+        "srcset": "^1.0.0",
+        "xtend": "^4.0.1"
       }
     },
     "scheduler": {
-      "version": "0.13.6",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
-      "integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.15.0.tgz",
+      "integrity": "sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==",
       "requires": {
-        "loose-envify": "1.4.0",
-        "object-assign": "4.1.1"
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
       }
-    },
-    "setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
     "source-map": {
       "version": "0.6.1",
@@ -1096,16 +1199,34 @@
       "resolved": "https://registry.npmjs.org/srcset/-/srcset-1.0.0.tgz",
       "integrity": "sha1-pWad4StC87HV6D7QPHEEb8SPQe8=",
       "requires": {
-        "array-uniq": "1.0.3",
-        "number-is-nan": "1.0.1"
+        "array-uniq": "^1.0.2",
+        "number-is-nan": "^1.0.0"
+      }
+    },
+    "string.prototype.trimleft": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
+      "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      }
+    },
+    "string.prototype.trimright": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
+      "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
       }
     },
     "string_decoder": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
-      "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "~5.2.0"
       }
     },
     "supports-color": {
@@ -1113,7 +1234,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "requires": {
-        "has-flag": "3.0.0"
+        "has-flag": "^3.0.0"
       }
     },
     "tslib": {
@@ -1127,31 +1248,26 @@
       "integrity": "sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q=="
     },
     "typescript": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.2.tgz",
-      "integrity": "sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==",
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
+      "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
       "dev": true
     },
     "typestyle": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/typestyle/-/typestyle-2.0.3.tgz",
-      "integrity": "sha512-F50kKkqIjK5PWyalj3xaqAIopjzCp/MIBD7BW3Hkc2PQhVhRcy/KX0l1uv3+KNGy3xAOIWUxzr8ZibTChp88Ww==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/typestyle/-/typestyle-2.0.4.tgz",
+      "integrity": "sha512-+57eGqcEjiAc51hB/zXnZFoVuzwuxb9WbPpb1VT2zPJPIo88wGXod7dHa0IJ1Ue+sncHj2WZMZEPJRAqwVraoA==",
       "requires": {
-        "csstype": "2.6.5",
+        "csstype": "^2.4.0",
         "free-style": "2.6.1"
       }
-    },
-    "ua-parser-js": {
-      "version": "0.7.20",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.20.tgz",
-      "integrity": "sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw=="
     },
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "requires": {
-        "punycode": "2.1.1"
+        "punycode": "^2.1.0"
       }
     },
     "url-parse": {
@@ -1159,8 +1275,8 @@
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
       "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
       "requires": {
-        "querystringify": "2.1.1",
-        "requires-port": "1.0.0"
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "util-deprecate": {
@@ -1173,13 +1289,8 @@
       "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
       "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
       "requires": {
-        "loose-envify": "1.4.0"
+        "loose-envify": "^1.0.0"
       }
-    },
-    "whatwg-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
     },
     "wrappy": {
       "version": "1.0.2",
@@ -1188,17 +1299,14 @@
       "dev": true
     },
     "ws": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.0.1.tgz",
-      "integrity": "sha512-ILHfMbuqLJvnSgYXLgy4kMntroJpe8hT41dOVWM8bxRuw6TK4mgMp9VJUNsZTEc5Bh+Mbs0DJT4M0N+wBG9l9A==",
-      "requires": {
-        "async-limiter": "1.0.0"
-      }
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
+      "integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ=="
     },
     "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,15 +19,16 @@
   ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "style": "style/index.css",
   "repository": {
     "type": "git",
     "url": "https://github.com/chaoleili/jupyterlab_tensorboard.git"
   },
   "scripts": {
     "build": "tsc",
-    "clean": "rimraf lib",
-    "watch": "tsc -w",
-    "prepare": "npm run clean && npm run build"
+    "clean": "rimraf lib tsconfig.tsbuildinfo",
+    "prepare": "jlpm run clean && jlpm run build",
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/application": "^2.0.0",
@@ -47,8 +48,11 @@
   },
   "devDependencies": {
     "rimraf": "^3.0.0",
-    "typescript": "~3.7.0"
+    "typescript": "~3.8.0"
   },
+  "sideEffects": [
+    "style/*.css"
+  ],
   "jupyterlab": {
     "extension": true
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab_tensorboard",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "description": "A JupyterLab extension for tensorboard.",
   "keywords": [
     "jupyter",
@@ -30,24 +30,24 @@
     "prepare": "npm run clean && npm run build"
   },
   "dependencies": {
-    "@jupyterlab/application": "^1.0.0",
-    "@jupyterlab/apputils": "^1.0.0",
-    "@jupyterlab/coreutils": "^3.0.0",
-    "@jupyterlab/launcher": "^1.0.0",
-    "@jupyterlab/services": "^4.0.0",
-    "@jupyterlab/mainmenu": "^1.0.0",
-    "@jupyterlab/filebrowser": "^1.0.0",
-    "@phosphor/algorithm": "^1.1.3",
-    "@phosphor/coreutils": "^1.3.1",
-    "@phosphor/disposable": "^1.2.0",
-    "@phosphor/domutils": "^1.1.2",
-    "@phosphor/messaging": "^1.2.3",
-    "@phosphor/signaling": "^1.2.3",
-    "@phosphor/widgets": "^1.8.0"
+    "@jupyterlab/application": "^2.0.0",
+    "@jupyterlab/apputils": "^2.0.0",
+    "@jupyterlab/coreutils": "^4.0.0",
+    "@jupyterlab/launcher": "^2.0.0",
+    "@jupyterlab/services": "^5.0.0",
+    "@jupyterlab/mainmenu": "^2.0.0",
+    "@jupyterlab/filebrowser": "^2.0.0",
+    "@lumino/algorithm": "^1.1.3",
+    "@lumino/coreutils": "^1.3.1",
+    "@lumino/disposable": "^1.2.0",
+    "@lumino/domutils": "^1.1.2",
+    "@lumino/messaging": "^1.2.3",
+    "@lumino/signaling": "^1.2.3",
+    "@lumino/widgets": "^1.8.0"
   },
   "devDependencies": {
-    "rimraf": "^2.6.1",
-    "typescript": "~3.5.1"
+    "rimraf": "^3.0.0",
+    "typescript": "~3.7.0"
   },
   "jupyterlab": {
     "extension": true

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -2,15 +2,15 @@
 
 import { 
   IIterator, ArrayExt, iter
-} from '@phosphor/algorithm';
+} from '@lumino/algorithm';
 
 import {
     Signal, ISignal
-} from '@phosphor/signaling';
+} from '@lumino/signaling';
 
 import {
   JSONExt
-} from '@phosphor/coreutils';
+} from '@lumino/coreutils';
 
 import { 
   Tensorboard

--- a/src/panel.ts
+++ b/src/panel.ts
@@ -4,15 +4,15 @@ import {
 
 import {
   Message
-} from '@phosphor/messaging';
+} from '@lumino/messaging';
 
 import {
   Widget
-} from '@phosphor/widgets';
+} from '@lumino/widgets';
 
 import {
     ElementExt
-} from '@phosphor/domutils';
+} from '@lumino/domutils';
 
 import {
   DOMUtils, Dialog, showDialog
@@ -24,7 +24,7 @@ import {
 
 import { 
   Signal, ISignal 
-} from '@phosphor/signaling';
+} from '@lumino/signaling';
 
 
 /**

--- a/src/tab.ts
+++ b/src/tab.ts
@@ -4,7 +4,7 @@ import {
 
 import {
   Message
-} from '@phosphor/messaging';
+} from '@lumino/messaging';
 
 import {
   Tensorboard
@@ -12,7 +12,7 @@ import {
 
 import { 
   Widget 
-} from '@phosphor/widgets';
+} from '@lumino/widgets';
 
 const TENSORBOARD_CLASS = 'jp-Tensorboard';
 

--- a/src/tensorboard.ts
+++ b/src/tensorboard.ts
@@ -1,15 +1,15 @@
 
 import { 
   each, map, toArray, IIterator
-} from '@phosphor/algorithm';
+} from '@lumino/algorithm';
 
 import {
   IDisposable
-} from '@phosphor/disposable';
+} from '@lumino/disposable';
 
 import {
   JSONObject
-} from '@phosphor/coreutils';
+} from '@lumino/coreutils';
 
 import {
   URLExt
@@ -17,7 +17,7 @@ import {
 
 import {
     Signal, ISignal
-} from '@phosphor/signaling';
+} from '@lumino/signaling';
 
 import {
     ServerConnection

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,24 @@
 {
   "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "composite": true,
     "declaration": true,
-    "lib": ["es2015", "dom"],
-    "module": "commonjs",
+    "esModuleInterop": true,
+    "incremental": true,
+    "jsx": "react",
+    "module": "esnext",
     "moduleResolution": "node",
     "noEmitOnError": true,
+    "noImplicitAny": true,
     "noUnusedLocals": true,
-    "outDir": "./lib",
-    "target": "es2015",
+    "preserveWatchOutput": true,
+    "resolveJsonModule": true,
+    "outDir": "lib",
+    "rootDir": "src",
     "strict": true,
     "strictNullChecks": false,
-    "types": [],
-    "allowSyntheticDefaultImports": true,
-    "jsx": "react"
+    "target": "es2017",
+    "types": []
   },
   "include": ["src/*"]
 }


### PR DESCRIPTION
JupyterLab 2.0.0 is out, and this extension have conflicting dependencies with its core packages. This PR is me following the JupyterLab migration guide referenced below, as I have now done for many other repositories successfully.

## PR Summary
1. I bump the version of this npm package to 0.2.0 from 0.1.6 in package.json.
2. I bump the @jupyterlab/... dependencies one major version.
3. I replace @phosphor with @lumino.
4. I updated this extension to align with practices from the cookiecutter template used to generate the repo initially, this was done in the final commit 1f9c504.
5. Releasing this will not break existing use of JupyterLab 1, but they will stay behind if new features are added, and the new features will only be available in JupyterLab 2.


## References
- [Change log for developers](https://jupyterlab.readthedocs.io/en/stable/getting_started/changelog.html#for-developers)
- [A migration guide](https://jupyterlab.readthedocs.io/en/stable/developer/extension_migration.html#extension-migration)